### PR TITLE
Allow editing previous form fields

### DIFF
--- a/components/direct-order/form/DirectOrderForm.vue
+++ b/components/direct-order/form/DirectOrderForm.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="mt-10">
     <div v-if="!submitting">
-      <ProgressIndicator v-if="currentStep <= 5" :steps="5" :current-step="currentStep" />
+      <ProgressIndicator 
+        v-if="currentStep <= 5" 
+        :steps="5" 
+        :current-step="currentStep" 
+        @select="setCurrentStep"
+      />
       <p v-if="error" class="text-center text-red-500 my-4">Something went wrong, please try again later</p>
       <div :class="{'mt-6 lg:mt-12': currentStep <= 5}">
         <ContactInfo v-show="currentStep === 1" @next="next" />
@@ -72,6 +77,9 @@ export default {
     },
     goBackToPreviousStep(){
       if (this.currentStep > 1) this.currentStep--
+    },
+    setCurrentStep(stepNum){
+      this.currentStep = stepNum
     },
     async onSubmit(){
       this.submitting = true

--- a/components/direct-order/form/DirectOrderForm.vue
+++ b/components/direct-order/form/DirectOrderForm.vue
@@ -5,11 +5,11 @@
       <p v-if="error" class="text-center text-red-500 my-4">Something went wrong, please try again later</p>
       <div :class="{'mt-6 lg:mt-12': currentStep <= 5}">
         <ContactInfo v-if="currentStep === 1" @next="next" />
-        <DateTime v-if="currentStep === 2" @next="next" />
-        <OrderSize v-if="currentStep === 3" @next="next" />
-        <Flavors v-if="currentStep === 4" @next="next" />
-        <Addons v-if="currentStep === 5" @next="next" />
-        <ReviewOrder v-if="currentStep === 6" @submit="onSubmit" />
+        <DateTime v-if="currentStep === 2" @next="next" @previous="goBackToPreviousStep" />
+        <OrderSize v-if="currentStep === 3" @next="next" @previous="goBackToPreviousStep" />
+        <Flavors v-if="currentStep === 4" @next="next" @previous="goBackToPreviousStep" />
+        <Addons v-if="currentStep === 5" @next="next" @previous="goBackToPreviousStep" />
+        <ReviewOrder v-if="currentStep === 6" @submit="onSubmit" @previous="goBackToPreviousStep" />
       </div>
     </div>
     <div v-else class="flex justify-center items-center h-screen">
@@ -69,6 +69,9 @@ export default {
   methods: {
     next(){
       this.currentStep++
+    },
+    goBackToPreviousStep(){
+      if (this.currentStep > 1) this.currentStep--
     },
     async onSubmit(){
       this.submitting = true

--- a/components/direct-order/form/DirectOrderForm.vue
+++ b/components/direct-order/form/DirectOrderForm.vue
@@ -4,12 +4,12 @@
       <ProgressIndicator v-if="currentStep <= 5" :steps="5" :current-step="currentStep" />
       <p v-if="error" class="text-center text-red-500 my-4">Something went wrong, please try again later</p>
       <div :class="{'mt-6 lg:mt-12': currentStep <= 5}">
-        <ContactInfo v-if="currentStep === 1" @next="next" />
-        <DateTime v-if="currentStep === 2" @next="next" @previous="goBackToPreviousStep" />
-        <OrderSize v-if="currentStep === 3" @next="next" @previous="goBackToPreviousStep" />
-        <Flavors v-if="currentStep === 4" @next="next" @previous="goBackToPreviousStep" />
-        <Addons v-if="currentStep === 5" @next="next" @previous="goBackToPreviousStep" />
-        <ReviewOrder v-if="currentStep === 6" @submit="onSubmit" @previous="goBackToPreviousStep" />
+        <ContactInfo v-show="currentStep === 1" @next="next" />
+        <DateTime v-show="currentStep === 2" @next="next" @previous="goBackToPreviousStep" />
+        <OrderSize v-show="currentStep === 3" @next="next" @previous="goBackToPreviousStep" />
+        <Flavors v-show="currentStep === 4" @next="next" @previous="goBackToPreviousStep" />
+        <Addons v-show="currentStep === 5" @next="next" @previous="goBackToPreviousStep" />
+        <ReviewOrder v-show="currentStep === 6" @submit="onSubmit" @previous="goBackToPreviousStep" />
       </div>
     </div>
     <div v-else class="flex justify-center items-center h-screen">

--- a/components/direct-order/form/ProgressIndicator.vue
+++ b/components/direct-order/form/ProgressIndicator.vue
@@ -1,68 +1,74 @@
 <template>
-    <div class="relative w-9/12 mx-auto flex items-center justify-between lg:w-4/12">
-        <div 
-            v-for="step in steps" 
-            :key="step" 
-            @click="onSelect(step)"
-            :class="{selected: step <= currentStep, 'cursor-pointer': isStepSelectable(step)}" 
-            class="step"
-            >
-        </div>
-        <div class="crossline progress" :style="{ '--step-index': currentStep - 1 }">
-        </div>
-        <div class="crossline"></div>
-    </div>
+  <div
+    class="relative w-9/12 mx-auto flex items-center justify-between lg:w-4/12"
+  >
+    <div
+      v-for="step in steps"
+      :key="step"
+      @click="onSelect(step)"
+      :class="{
+        selected: step <= currentStep,
+        'cursor-pointer': isStepSelectable(step),
+      }"
+      class="step"
+    ></div>
+    <div
+      class="crossline progress"
+      :style="{ '--step-index': currentStep - 1 }"
+    ></div>
+    <div class="crossline"></div>
+  </div>
 </template>
 
 <script>
 export default {
-    props: {
-        steps: {
-            required: true,
-            type: Number
-        },
-        currentStep: {
-            required: true,
-            type: Number
-        },
+  props: {
+    steps: {
+      required: true,
+      type: Number,
     },
-    methods: {
-        isStepSelectable(step){
-            return step < this.currentStep // We can only go back to preceding steps
-        },
-        onSelect(step){
-            if (!this.isStepSelectable(step)) return
+    currentStep: {
+      required: true,
+      type: Number,
+    },
+  },
+  methods: {
+    isStepSelectable(step) {
+      return step < this.currentStep; // We can only go back to preceding steps
+    },
+    onSelect(step) {
+      if (!this.isStepSelectable(step)) return;
 
-            this.$emit('select', step)
-        }
-    }
-}
+      this.$emit("select", step);
+    },
+  },
+};
 </script>
 
 <style scoped>
 .step {
-    @apply w-4 h-4 rounded-full;
-    background: #d9d9d9;
+  @apply w-4 h-4 rounded-full;
+  background: #d9d9d9;
 }
 
 .step.selected {
-    background: #00b373;
+  background: #00b373;
 }
 
 .crossline {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: #d9d9d9;
-    z-index: -2;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: #d9d9d9;
+  z-index: -2;
 }
 
 .crossline.progress {
-    --step-index: 0;
-    width: calc(100% / 4 * var(--step-index));
-    background: #00b373;
-    z-index: -1;
+  --step-index: 0;
+  width: calc(100% / 4 * var(--step-index));
+  background: #00b373;
+  z-index: -1;
 }
 </style>

--- a/components/direct-order/form/ProgressIndicator.vue
+++ b/components/direct-order/form/ProgressIndicator.vue
@@ -1,6 +1,13 @@
 <template>
     <div class="relative w-9/12 mx-auto flex items-center justify-between lg:w-4/12">
-        <div v-for="step in steps" :key="step" :class="{selected: step <= currentStep}" class="step"></div>
+        <div 
+            v-for="step in steps" 
+            :key="step" 
+            @click="onSelect(step)"
+            :class="{selected: step <= currentStep, 'cursor-pointer': isStepSelectable(step)}" 
+            class="step"
+            >
+        </div>
         <div class="crossline progress" :style="{ '--step-index': currentStep - 1 }">
         </div>
         <div class="crossline"></div>
@@ -18,6 +25,16 @@ export default {
             required: true,
             type: Number
         },
+    },
+    methods: {
+        isStepSelectable(step){
+            return step < this.currentStep // We can only go back to preceding steps
+        },
+        onSelect(step){
+            if (!this.isStepSelectable(step)) return
+
+            this.$emit('select', step)
+        }
     }
 }
 </script>

--- a/components/direct-order/form/steps/Addons.vue
+++ b/components/direct-order/form/steps/Addons.vue
@@ -28,6 +28,9 @@
         <button @click="$emit('next')" class="btn btn-primary w-full p-3 mt-10">
           REVIEW
         </button>
+        <button class="btn btn-secondary w-full p-3 mt-2 underline" @click="$emit('previous')">
+          Previous step
+        </button>
       </div>
       <div class="hidden lg:block">
         <img src="~/assets/img/howdy2.png" alt="Howdy Breakfast Buns" />

--- a/components/direct-order/form/steps/DateTime.vue
+++ b/components/direct-order/form/steps/DateTime.vue
@@ -77,11 +77,14 @@
           >
             Next: ORDER SIZE
           </button>
+          <button class="btn btn-secondary w-full p-3 mt-2 underline" @click="$emit('previous')">
+            Previous step
+          </button>
         </div>
       </div>
       <div class="hidden lg:block">
         <img src="~/assets/img/howdy2.png" alt="Howdy Breakfast Buns" />
-      </div>
+      </div>  
     </div>
   </div>
 </template>

--- a/components/direct-order/form/steps/Flavors.vue
+++ b/components/direct-order/form/steps/Flavors.vue
@@ -61,6 +61,9 @@
           >
             Next: ADD-ONS
           </button>
+          <button class="btn btn-secondary w-full p-3 mt-2 underline" @click="$emit('previous')">
+            Previous step
+          </button>
         </div>
       </div>
       <div class="hidden lg:block">

--- a/components/direct-order/form/steps/OrderSize.vue
+++ b/components/direct-order/form/steps/OrderSize.vue
@@ -58,6 +58,9 @@
         >
           Next: SELECT MIX
         </button>
+        <button class="btn btn-secondary w-full p-3 mt-2 underline" @click="$emit('previous')">
+          Previous step
+        </button>
       </div>
       <div class="hidden lg:block">
         <img src="~/assets/img/howdy2.png" alt="Howdy Breakfast Buns" />

--- a/components/direct-order/form/steps/ReviewOrder.vue
+++ b/components/direct-order/form/steps/ReviewOrder.vue
@@ -97,6 +97,9 @@
         <button @click="$emit('submit')" class="btn btn-primary w-full p-3 mt-10">
           PAY
         </button>
+        <button class="btn btn-secondary w-full p-3 mt-2 underline" @click="$emit('previous')">
+          Previous step
+        </button>
       </div>
       <div class="hidden lg:block">
         <img src="~/assets/img/howdy2.png" alt="Howdy Breakfast Buns" />

--- a/store/order-form.js
+++ b/store/order-form.js
@@ -1,5 +1,26 @@
 export const state = () => ({
-  fields: {},
+  fields: {
+    contact: {
+      name: '',
+      email: '',
+      phoneNumber: '',
+    },
+    delivery: {
+      date: null,
+      deliveryTime: null,
+      orderType: "Pickup",
+      address: '',
+      deliveryNotes: '',
+    },
+    flavors: '',
+    size: {
+      numberOfPeople: 1,
+      bunsPerPerson: 1,
+      dozens: 1,
+      kolachesCostInCents: 5900
+    },
+    addons: []
+  },
 });
 
 export const mutations = {


### PR DESCRIPTION
Adds the ability to go back and edit previous steps in two ways:
- The 1st way is by using the “Previous step” button below the primary button 
- Alternatively, users can go back to previous steps by clicking on the corresponding "circle" in the progress indicator

I believe the latter method has some advantages, such as being able to go back to a specific step in a single click (without passing through the steps between the target and current steps). It may not be as obvious as the first method to users, so we may need to update the UI in order to let the user know that these circles are clickable and can be used to navigate through the steps.

@ezl  What do you think should we keep both as options?

