### PR TITLE
Fix: selected delivery time being invalid after picking a date

### DIFF
--- a/components/direct-order/form/steps/DateTime.vue
+++ b/components/direct-order/form/steps/DateTime.vue
@@ -27,9 +27,8 @@
             <multiselect
               v-model="fields.deliveryTime" 
               :options="availableHours"
-              @select="onHourSelect"
-              label="hour"
-              track-by="hour"
+              :show-labels="false"
+              @input="onChange"
               placeholder=""
               tagPosition="bottom"
               >
@@ -140,15 +139,11 @@ export default {
       const hourList = []
 
       // add the initial start time
-      hourList.push({
-        hour: fromTime.format(format)
-      })
+      hourList.push(fromTime.format(format))
 
       while (true) {
         fromTime.add(15, 'minutes')
-        hourList.push({
-          hour: fromTime.format(format)
-        })
+        hourList.push(fromTime.format(format))
 
         if (fromTime.isSameOrAfter(toTime)) break
       }
@@ -179,10 +174,6 @@ export default {
       this.update({
         delivery: { ...this.fields },
       });
-    },
-    onHourSelect(obj){
-      this.fields.deliveryTime = obj.hour
-      this.onChange()
     }
   },
   mounted(){


### PR DESCRIPTION
**The issue:**
Since we were supplying the list of available hours as an array of objects to `multiselect` component through the “options” prop, we were getting back the selected option as an object `{ hour: ‘7:45 am’ } `and (because we needed `this.fields.deliveryTime` to be a plain string ) we had to manually re-assign `this.fields.deliveryTime`’s value to `this.fields.deliveryTime.hour` whenever it changed. Which was inconsistent at times, for example when picking a date after selecting the time. 

**The fix:**
I supplied the list of available hours as an array of strings to multiselect, instead of providing them as an array of objects. So we are now getting back selected hour as a string