### PR TITLE
Prevent order form from resetting on refresh

### DIFF
--- a/mixins/order-form/form-step-mixin.js
+++ b/mixins/order-form/form-step-mixin.js
@@ -1,6 +1,12 @@
 import { mapGetters, mapActions } from "vuex";
+import moment from 'moment'
 
 export default {
+  data() {
+    return {
+      localStorageItemKey: 'orderFormData'
+    }
+  },
   computed: {
     ...mapGetters({
       form: "order-form/fields",
@@ -24,5 +30,38 @@ export default {
 
       this.$router.push(route);
     },
+    saveFormDataInLocalStorage (formFields) {
+      const value = JSON.stringify({
+        updatedAt: moment().unix(),
+        data: { ...formFields }
+      })
+
+      localStorage.setItem(this.localStorageItemKey, value)
+    },
+    getFormDataFromLocalStorage(){
+      const value = localStorage.getItem(this.localStorageItemKey)
+
+      return value ? JSON.parse(value) : null
+    },
+  },
+  mounted() {
+    // Retrieve previously saved form data from the local storage
+    const formDataFromLocalStorage = this.getFormDataFromLocalStorage()
+    // If there’s indeed previous values, overwrite current store with these values 
+    if (formDataFromLocalStorage) {
+      // Note: this will only overwrite state.fields properly, the rest of the state won;t be affected 
+      this.update(formDataFromLocalStorage.data);
+    }
+  },
+  watch: {
+    'form': {
+      // Whenever the “this.form” value changes 
+      // (which maps to the “fields” property in order-form.js’s state)
+      handler: function (newValue) {
+        // Save the new value in local storage
+        this.saveFormDataInLocalStorage(newValue)
+      },
+      deep: true
+    }
   }
 };

--- a/pages/order/direct/form/review.vue
+++ b/pages/order/direct/form/review.vue
@@ -35,6 +35,7 @@ import { mapGetters, mapActions } from "vuex";
 import OrderInfoOverview from "@/components/direct-order/form/review/OrderInfoOverview.vue";
 import OrderTotals from "@/components/direct-order/form/review/OrderTotals.vue";
 import PreviousStepButton from "@/components/direct-order/form/PreviousStepButton.vue"
+import formStepMixin from "@/mixins/order-form/form-step-mixin";
 
 export default {
   components: {
@@ -42,6 +43,7 @@ export default {
     OrderTotals,
     PreviousStepButton
   },
+  mixins: [formStepMixin],
   data() {
     return {
       submitting: false,


### PR DESCRIPTION
Order form data is now being saved to the local storage, now refreshing will not reset filled fields 